### PR TITLE
Adding goaws and AWS credentials setup

### DIFF
--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -100,3 +100,14 @@ logrotate-for-annotations-logs:
     file.managed:
         - name: /etc/logrotate.d/annotations
         - source: salt://annotations/config/etc-logrotate.d-annotations
+
+{% if pillar.elife.env in ['dev', 'ci'] %}
+annotations-queue-create:
+    cmd.run:
+        - name: aws sqs create-queue --region=us-east-1 --queue-name=annotations--{{ pillar.elife.env }} --endpoint=http://localhost:4100
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - goaws
+            - aws-credentials-deploy-user
+{% endif %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -12,4 +12,3 @@ base:
         - elife.proofreader-php
         - elife.docker
         - elife.goaws
-

--- a/salt/example.top
+++ b/salt/example.top
@@ -5,5 +5,11 @@ base:
         - elife.composer
         - elife.nginx
         - elife.nginx-php7
-        - elife.proofreader-php
+        - elife.aws-credentials
+        - elife.aws-cli
         - annotations
+        # for testing
+        - elife.proofreader-php
+        - elife.docker
+        - elife.goaws
+

--- a/salt/pillar/annotations.sls
+++ b/salt/pillar/annotations.sls
@@ -7,3 +7,8 @@ annotations:
     secret: ThisTokenIsNotSoSecretChangeIt
 
     web_users: {}
+
+elife:
+    aws:
+        access_key_id: AKIAFAKE
+        secret_access_key: fake


### PR DESCRIPTION
Two slightly overlapping concerns:
- provision the AWS credentials so that the application can talk to SQS
- provide a fake implementation, `goaws`, for testing in `ci` and `dev`