### PR TITLE
Change config format to recommendations example

### DIFF
--- a/salt/annotations/config/srv-annotations-config.php
+++ b/salt/annotations/config/srv-annotations-config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'secret' => '{{ pillar.annotations.secret }}',
+    'hypothesis_api_url' => '{{ pillar.annotations.hypothesis_api_url }}',
+    'hypothesis_api_publisher' => '{{ pillar.annotations.hypothesis_api_publisher }}',
+    'ttl' => {{ pillar.annotations.ttl }},
+];

--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -56,8 +56,8 @@ var-directory:
 
 config-file:
     file.managed:
-        - name: /srv/annotations/app/config/parameters.yml
-        - source: salt://annotations/config/srv-annotations-app-config-parameters.yml
+        - name: /srv/annotations/config.php
+        - source: salt://annotations/config/srv-annotations-config.php
         - template: jinja
         - user: {{ pillar.elife.deploy_user.username }}
         - group: {{ pillar.elife.deploy_user.username }}

--- a/salt/pillar/annotations.sls
+++ b/salt/pillar/annotations.sls
@@ -2,11 +2,7 @@ annotations:
     hypothesis_api_url: https://hypothes.is/
     hypothesis_api_publisher: __world__
     ttl: 0
-    default_host: null
-
     secret: ThisTokenIsNotSoSecretChangeIt
-
-    web_users: {}
 
 elife:
     aws:


### PR DESCRIPTION
Provides a config.php file in the root of the project, that can be used or merged with other defaults by the application