### PR TITLE
ELPP-3361 Allow FPM container deployment on end2end

### DIFF
--- a/salt/annotations/config/etc-nginx-sites-enabled-annotations.conf
+++ b/salt/annotations/config/etc-nginx-sites-enabled-annotations.conf
@@ -11,11 +11,15 @@ server {
     location ~ ^/app_{{ pillar.elife.env }}\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;
+        fastcgi_intercept_errors on;
         fastcgi_param SCRIPT_FILENAME $request_filename;
+        {% if pillar.annotations.containerized %}
+        fastcgi_pass localhost:9000;
+        {% else %}
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param ENVIRONMENT_NAME {{ pillar.elife.env }};
-        fastcgi_intercept_errors on;
         fastcgi_pass unix:/var/php-fpm.sock;
+        {% endif %}
         internal;
     }
 

--- a/salt/annotations/config/home-deployuser-.env
+++ b/salt/annotations/config/home-deployuser-.env
@@ -1,3 +1,2 @@
 COMPOSE_PROJECT_NAME=annotations
-# TODO: should be derived from build vars
-IMAGE_TAG=latest
+IMAGE_TAG={{ salt['elife.rev']('latest') }}

--- a/salt/annotations/config/home-deployuser-.env
+++ b/salt/annotations/config/home-deployuser-.env
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=annotations
+# TODO: should be derived from build vars
+IMAGE_TAG=latest

--- a/salt/annotations/config/home-deployuser-annotations-docker-compose.yml
+++ b/salt/annotations/config/home-deployuser-annotations-docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+    fpm:
+        image: "elifesciences/annotations_fpm:${IMAGE_TAG}"
+        volumes:
+            - /srv/annotations/config.php:/srv/annotations/config.php
+            - /srv/annotations/var/logs:/srv/annotations/var/logs
+            - /var/www/.aws/credentials/:/var/www/.aws/credentials
+        env_file:
+            - /home/{{ pillar.elife.deploy_user.username }}/annotations.env
+        ports:
+            - 9000:9000
+

--- a/salt/annotations/config/home-deployuser-annotations.env
+++ b/salt/annotations/config/home-deployuser-annotations.env
@@ -1,0 +1,1 @@
+ENVIRONMENT_NAME={{ pillar.elife.env }}

--- a/salt/annotations/containers.sls
+++ b/salt/annotations/containers.sls
@@ -1,0 +1,30 @@
+{% if pillar.annotations.containerized %}
+
+# variable for docker-compose
+annotations-docker-compose-.env:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/.env
+        - source: salt://annotations/config/home-deployuser-.env
+        - template: jinja
+
+# variables for the containers
+annotations-containers-env:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/annotations.env
+        - source: salt://annotations/config/home-deployuser-annotations.env
+        - template: jinja
+
+annotations-docker-compose-yml:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/annotations-docker-compose.yml
+        - source: salt://annotations/config/home-deployuser-annotations-docker-compose.yml
+        - template: jinja
+
+annotations-docker-containers:
+    cmd.run:
+        - name: /usr/local/bin/docker-compose -f /home/elife/annotations-docker-compose.yml up --force-recreate -d
+        - user: {{ pillar.elife.deploy_user.username }}
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}
+        #TODO: require
+
+{% endif %}

--- a/salt/annotations/containers.sls
+++ b/salt/annotations/containers.sls
@@ -6,6 +6,8 @@ annotations-docker-compose-.env:
         - name: /home/{{ pillar.elife.deploy_user.username }}/.env
         - source: salt://annotations/config/home-deployuser-.env
         - template: jinja
+        - require:
+            - deploy-user
 
 # variables for the containers
 annotations-containers-env:
@@ -13,18 +15,25 @@ annotations-containers-env:
         - name: /home/{{ pillar.elife.deploy_user.username }}/annotations.env
         - source: salt://annotations/config/home-deployuser-annotations.env
         - template: jinja
+        - require:
+            - deploy-user
 
 annotations-docker-compose-yml:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/annotations-docker-compose.yml
         - source: salt://annotations/config/home-deployuser-annotations-docker-compose.yml
         - template: jinja
+        - require:
+            - deploy-user
 
 annotations-docker-containers:
     cmd.run:
         - name: /usr/local/bin/docker-compose -f /home/elife/annotations-docker-compose.yml up --force-recreate -d
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /home/{{ pillar.elife.deploy_user.username }}
-        #TODO: require
+        - require:
+            - annotations-docker-compose-.env
+            - annotations-containers-env
+            - annotations-docker-compose-yml
 
 {% endif %}

--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -104,3 +104,14 @@ logrotate-for-annotations-logs:
     file.managed:
         - name: /etc/logrotate.d/annotations
         - source: salt://annotations/config/etc-logrotate.d-annotations
+
+{% if pillar.elife.env in ['dev', 'ci'] %}
+annotations-queue-create:
+    cmd.run:
+        - name: aws sqs create-queue --region=us-east-1 --queue-name=annotations--{{ pillar.elife.env }} --endpoint=http://localhost:4100
+        - cwd: /home/{{ pillar.elife.deploy_user.username }}
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - goaws
+            - aws-credentials-deploy-user
+{% endif %}

--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -50,7 +50,11 @@ var-directory:
             - builder: annotations-repository
 
     cmd.run:
-        - name: chmod -R g+s /srv/annotations/var
+        - name: |
+            chmod -R g+s /srv/annotations/var
+            mkdir -p /srv/annotations/var/logs
+            chown elife:www-data /srv/annotations/var/logs
+            chmod 775 /srv/annotations/var/logs
         - require:
             - file: var-directory
 

--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -104,14 +104,3 @@ logrotate-for-annotations-logs:
     file.managed:
         - name: /etc/logrotate.d/annotations
         - source: salt://annotations/config/etc-logrotate.d-annotations
-
-{% if pillar.elife.env in ['dev', 'ci'] %}
-annotations-queue-create:
-    cmd.run:
-        - name: aws sqs create-queue --region=us-east-1 --queue-name=annotations--{{ pillar.elife.env }} --endpoint=http://localhost:4100
-        - cwd: /home/{{ pillar.elife.deploy_user.username }}
-        - user: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - goaws
-            - aws-credentials-deploy-user
-{% endif %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -8,9 +8,9 @@ base:
         - elife.aws-credentials
         - elife.aws-cli
         - annotations
+        - elife.docker
+        - annotations.containers
         - elife.php-long-running-processes
         # for testing
         - elife.php-dummies
         - elife.proofreader-php
-        - elife.docker
-        - elife.goaws

--- a/salt/example.top
+++ b/salt/example.top
@@ -14,3 +14,4 @@ base:
         - elife.php-long-running-processes
         # for testing
         - elife.php-dummies
+        - elife.goaws

--- a/salt/example.top
+++ b/salt/example.top
@@ -4,6 +4,7 @@ base:
         - elife.php7
         - elife.composer
         - elife.nginx
+        # deprecated in this project, remove when unnecessary
         - elife.nginx-php7
         - elife.aws-credentials
         - elife.aws-cli
@@ -13,4 +14,3 @@ base:
         - elife.php-long-running-processes
         # for testing
         - elife.php-dummies
-        - elife.proofreader-php

--- a/salt/pillar/annotations.sls
+++ b/salt/pillar/annotations.sls
@@ -16,6 +16,7 @@ annotations:
             client_secret: fake
         authority: null
         group: null
+    containerized: true
 
 elife:
     aws:


### PR DESCRIPTION
After this is applied, the `php-fpm` running on the host is substituted by the `php-fpm` running inside a container. Smoke tests run (testing in Vagrant with the feature flag enabled) by hitting the local nginx and this container.