### PR TITLE
Remove git repository

### DIFF
--- a/salt/annotations/config/srv-annotations-smoke_tests.sh
+++ b/salt/annotations/config/srv-annotations-smoke_tests.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+set -e
 . /opt/smoke.sh/smoke.sh
 
+cd /home/{{ pillar.elife.deploy_user.username }}/annotations
+docker-compose exec queue_watch ./smoke_tests_cli.sh
+docker-compose exec fpm ./smoke_tests_fpm.sh
+
+set +e
 smoke_url_ok localhost/ping
 smoke_report
 

--- a/salt/annotations/config/srv-annotations-smoke_tests.sh
+++ b/salt/annotations/config/srv-annotations-smoke_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+. /opt/smoke.sh/smoke.sh
+
+smoke_url_ok localhost/ping
+smoke_report
+

--- a/salt/annotations/init.sls
+++ b/salt/annotations/init.sls
@@ -99,6 +99,7 @@ integration-smoke-tests:
     file.managed:
         - name: /srv/annotations/smoke_tests.sh
         - source: salt://annotations/config/srv-annotations-smoke_tests.sh
+        - template: jinja
         - user: {{ pillar.elife.deploy_user.username }}
         - mode: 755
         - require: 

--- a/salt/example.top
+++ b/salt/example.top
@@ -1,17 +1,12 @@
 base:
     '*':
         - elife
-        - elife.php7
-        - elife.composer
         - elife.nginx
-        - elife.nginx-php7
         - elife.aws-credentials
         - elife.aws-cli
         - elife.docker
         - elife.sidecars
+        # for testing
+        - elife.goaws
         - annotations
         - annotations.containers
-        # for testing
-        # deprecated:
-        - elife.php-dummies
-        - elife.goaws


### PR DESCRIPTION
Provides a substitute smoke tests, which was the last thing remaining in the repository not available through the images. The new smoke tests pulls together smoke tests inside the images with a general /ping on the local nginx.