### PR TITLE
Correct extension of log files to rotate

### DIFF
--- a/salt/annotations/config/etc-logrotate.d-annotations
+++ b/salt/annotations/config/etc-logrotate.d-annotations
@@ -1,4 +1,4 @@
-/srv/annotations/var/logs/*.log {
+/srv/annotations/var/logs/*.json {
     daily
     rotate 7
     notifempty


### PR DESCRIPTION
They have never been rotated so far, due to the mismatch.