### PR TITLE
Correct log rotation and upload

### DIFF
--- a/salt/annotations/config/etc-logrotate.d-annotations
+++ b/salt/annotations/config/etc-logrotate.d-annotations
@@ -1,4 +1,4 @@
-/srv/annotations/var/logs/*.log {
+/srv/annotations/var/logs/*.json {
     daily
     rotate 7
     notifempty

--- a/salt/annotations/config/etc-syslog-ng-conf.d-annotations.conf
+++ b/salt/annotations/config/etc-syslog-ng-conf.d-annotations.conf
@@ -1,7 +1,7 @@
 @version: 3.5
 
 source s_annotations_application {
-    file("/srv/annotations/var/logs/{{ pillar.elife.env }}.json.log" 
+    file("/srv/annotations/var/logs/all.json" 
          follow_freq(1)
          program_override("annotations")
          flags(no-parse) 


### PR DESCRIPTION
These are the available log files:

```
elife@prod--annotations:~$ ls -lh /srv/annotations/var/logs/
total 838M
-rw-rwS--- 1 www-data www-data 831M Jul 30 11:45 all.json
-rw-rwS--- 1 www-data www-data 6.6M Jul 30 11:34 error.json
```

`all` contains all entries, while `error` is a copy of the ones with `ERROR` level or higher. We upload the first to Loggly, and rotate them both every day.